### PR TITLE
Fix: Android: Catch exceptions on multiple SDK initialization causing…

### DIFF
--- a/android/src/main/java/com/qubit/reactnative/sdk/QubitSDKModule.java
+++ b/android/src/main/java/com/qubit/reactnative/sdk/QubitSDKModule.java
@@ -44,11 +44,15 @@ public class QubitSDKModule extends ReactContextBaseJavaModule {
   @ReactMethod
   public void init(String trackingId, String logLevel) {
     QBLogLevel qbLogLevel = parseLogLevel(logLevel);
-    QubitSDK.initialization()
-        .inAppContext(reactContext)
-        .withTrackingId(trackingId)
-        .withLogLevel(qbLogLevel)
-        .start();
+    try {
+      QubitSDK.initialization()
+          .inAppContext(reactContext)
+          .withTrackingId(trackingId)
+          .withLogLevel(qbLogLevel)
+          .start();
+    } catch (Exception e) {
+      Log.w("Bridge", "Exception occurred during sdk initialization: " + e.getMessage());
+    }
   }
 
   @ReactMethod


### PR DESCRIPTION
… application crash.

Android SDK throws exception after attempt of initialization of SDK, when it is already initialized. It causes crashes of application, because bridge Javascript->Java doesn't support passing exceptions.
On the other hand, iOS implementation is silent, when SDK is initialized second time.
ReactNative SDK should work the same for both platforms. To unify behaviour of both platform, Android implementation is changed to be silent in this case, similarly to iOS implementation. Only warning log is written.