### PR TITLE
[LENS-1324] Adds examples on setting new deviceId

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,26 @@ async () => {
 
 Returns **[Promise](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)&lt;[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)>** Promise with String deviceId.
 
+You can set a new `deviceId` by calling the native method `restartWithCustomDeviceID`.
+The restart clears all the caches and resends startup events.
+
+**Objective-C**
+
+```objective-c
+NSString *newDeviceID = @"YourNewDeviceID";
+[QubitSDK restartWithCustomDeviceID:newDeviceID];
+```
+
+**Swift**
+
+```swift
+let newDeviceID = "yourNewDeviceID"
+QubitSDK.restartWithCustomDeviceID(id: newDeviceID)
+```
+```java
+QubitSDK.restartWithCustomDeviceId("yourNewDeviceID")
+```
+
 #### getLookupData
 
 Returns current Lookup Data. Debug purposes.

--- a/README.md
+++ b/README.md
@@ -164,6 +164,9 @@ NSString *newDeviceID = @"YourNewDeviceID";
 let newDeviceID = "yourNewDeviceID"
 QubitSDK.restartWithCustomDeviceID(id: newDeviceID)
 ```
+
+**Java**
+
 ```java
 QubitSDK.restartWithCustomDeviceId("yourNewDeviceID")
 ```


### PR DESCRIPTION
This PR adds examples on how to set a new `deviceId`.
README already had the examples on how to get the current `deviceId` and `trackingId`.
https://coveord.atlassian.net/browse/LENS-1324